### PR TITLE
fix position of drip-ctn

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -171,7 +171,7 @@ input {
 /* Icing Drips */
 
 .drip-ctn{
-    position:absolute;
+    position:absolute
     top:0;
     z-index:1;
 }


### PR DESCRIPTION
introduce a new error to bring back the correct position (was an error previously, but works fine)